### PR TITLE
Add empty <application /> tag to AndroidManifest.xml

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,4 +6,6 @@
     <uses-sdk
         android:minSdkVersion="10"
         android:targetSdkVersion="10" />
+
+    <application />
 </manifest>


### PR DESCRIPTION
Android Studio requires an <application> tag in AndroidManifest.xml

I added an empty one to make it happy.
