### PR TITLE
Fix parsing device descriptions with character entities.

### DIFF
--- a/src/com/connectsdk/core/upnp/Device.java
+++ b/src/com/connectsdk/core/upnp/Device.java
@@ -137,7 +137,12 @@ public class Device {
             
             @Override
             public void characters(char[] ch, int start, int length) throws SAXException {
-                currentValue = new String(ch, start, length);
+                if (currentValue == null) {
+                    currentValue = new String(ch, start, length);
+                } else {
+                    // append to existing string (needed for parsing character entities)
+                    currentValue += new String(ch, start, length);
+                }
             }
             
             @Override
@@ -148,7 +153,7 @@ public class Device {
                     currentService = new Service();
                     currentService.baseURL = device.baseURL;
                 }
-                
+                currentValue = null;
             }
             
             @Override
@@ -208,6 +213,8 @@ public class Device {
                 } else if (Service.TAG.equals(qName)) {
                     device.serviceList.add(currentService);
                 }
+
+                currentValue = null;
             }
         };
         


### PR DESCRIPTION
The characters() SAX handler may be called multiple times for the
same XML element when there are XML character entities. We need to
append the characters to the current string value.
