### PR TITLE
Added JSON parsing to App and Channel Info

### DIFF
--- a/src/com/connectsdk/core/AppInfo.java
+++ b/src/com/connectsdk/core/AppInfo.java
@@ -95,6 +95,15 @@ public class AppInfo implements JSONSerializable {
 	}
 	// @endcond
 	
+	// @cond INTERNAL
+	public AppInfo fromJSONObject(JSONObject obj) throws JSONException {
+		this.setId(obj.optString("id"));
+		this.setName(obj.optString("name"));
+		
+		return this;
+	}
+	// @endcond
+	
 	/**
 	 * Compares two AppInfo objects.
 	 *

--- a/src/com/connectsdk/core/ChannelInfo.java
+++ b/src/com/connectsdk/core/ChannelInfo.java
@@ -154,4 +154,17 @@ public class ChannelInfo implements JSONSerializable {
 		return obj;
 	}
 	// @endcond
+	
+	// @cond INTERNAL
+	public ChannelInfo fromJSONObject(JSONObject obj) throws JSONException {
+		setName(obj.optString("name"));
+		setNumber(obj.optString("number"));
+		setId(obj.optString("id"));
+		setMajorNumber(obj.optInt("majorNumber"));
+		setMinorNumber(obj.optInt("minorNumber"));
+		setRawData(obj);
+		
+		return this;
+	}
+	// @endcond
 }


### PR DESCRIPTION
Added json parsers for AppInfo and ChannelInfo objects so that we can transfer them over mediums most fit for non-java objects (persistent storage, http transfers).
Eventually **JSONSerializable** will also need a **fromJSON** method forcing every object to implement this.
