### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-#Contributing to Connect SDK
+# Contributing to Connect SDK
 
-##General Questions
+## General Questions
 
 Please do not use GitHub issues for general questions about the SDK. Instead, use any of the following services to reach out to the development team.
 
@@ -8,38 +8,38 @@ Please do not use GitHub issues for general questions about the SDK. Instead, us
 - Stack Overflow: [Connect-SDK tag](https://stackoverflow.com/tags/connect-sdk) (or [TV tag](https://stackoverflow.com/tags/tv))
 - [support@connectsdk.com](mailto:support@connectsdk.com)
 
-##Versioning
+## Versioning
 
 We use [semantic versioning](http://semver.org/) in our tagged releases.
 
-##Branching Strategy
+## Branching Strategy
 
 We use the [successful git branching model](http://nvie.com/posts/a-successful-git-branching-model/), except without release branches, and the `develop` branch is named `dev`.
 
-##Bug Reports & Feature Requests
+## Bug Reports & Feature Requests
 
 We use GitHub's issues system for managing bug reports and some upcoming features. Just open an issue and a member of the team will set the appropriate assignee, label, & milestone.
 
-###Crash Reports
+### Crash Reports
 
 If you experience a crash, please attach your symbolicated crash log or stack trace to an issue in GitHub.
 
-##Pull Requests
+## Pull Requests
 
 If you would like to submit code, please fork the repository on GitHub and develop in a feature branch, created from the latest `dev` commit. We do not accept pull requests on the `master` branch, as we only merge QA'd and tagged code into the `master` branch.
 
-###Tests
+### Tests
 
 Please include unit tests for the new/changed functionality with your pull request. It will help to verify the code is working as designed and make sure there are no regressions in future releases.
 
-###Use of third party libraries
+### Use of third party libraries
 
 Connect SDK includes some third party libraries. If you'd like to integrate a library with a pull request, make sure that library has an open source license (MIT, Apache 2.0, etc).
 
-###Licensing
+### Licensing
 
 If you submit a pull request, you acknowledge that your code will be released to the public under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html). Make sure that you have the rights to the code you are submitting in the pull request.
 
-##Testing Lab
+## Testing Lab
 
 In the development of Connect SDK, we have gathered a number of devices for testing purposes. If you are contributing to and/or integrating Connect SDK & would like something tested in our lab, you may contact [partners@connectsdk.com](mailto:partners@connectsdk.com) with your request.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Connect SDK Android
+# Connect SDK Android
 
 [![Build Status](https://travis-ci.org/ConnectSDK/Connect-SDK-Android.svg)](https://travis-ci.org/ConnectSDK/Connect-SDK-Android)
 [![Code Coverage](https://img.shields.io/codecov/c/github/ConnectSDK/Connect-SDK-Android/dev.svg)](https://codecov.io/github/ConnectSDK/Connect-SDK-Android)
@@ -15,7 +15,7 @@ For more information, visit our [website](http://www.connectsdk.com/).
 * [Platform documentation & FAQs](http://www.connectsdk.com/docs/android/)
 * [API documentation](http://www.connectsdk.com/apis/android/)
 
-##Dependencies
+## Dependencies
 This project has the following dependencies, some of which require manual setup. If you would like to use a version of the SDK which has no manual setup, consider using the [lite version](https://github.com/ConnectSDK/Connect-SDK-Android-Lite) of the SDK.
 
 This project has the following dependencies.
@@ -27,7 +27,7 @@ This project has the following dependencies.
 * [Connect-SDK-Android-FireTV](https://github.com/ConnectSDK/Connect-SDK-Android-FireTV) submodule
   - Requires [AmazonFling.framework](https://developer.amazon.com/public/apis/experience/fling/docs/amazon-fling-sdk-download)
 
-##Including Connect SDK in your app with Android Studio
+## Including Connect SDK in your app with Android Studio
 Edit your project's build.gradle to add this in the "dependencies" section
 ```groovy
 dependencies {
@@ -38,7 +38,7 @@ dependencies {
 This prebuilt library doesn't have Amazon Fling SDK support, because it’s not available on maven. You need to set the project up from sources
 if you want to have Amazon Fling SDK support.
 
-##Including Connect SDK in your app with Android Studio from sources
+## Including Connect SDK in your app with Android Studio from sources
 1. Open your terminal and execute these commands
     ```
     cd your_project_folder
@@ -64,7 +64,7 @@ if you want to have Amazon Fling SDK support.
 5. Sync project with gradle files
 6. Add permissions to your manifest
 
-###Permissions to include in manifest
+### Permissions to include in manifest
 * Required for SSDP & Chromecast/Zeroconf discovery
  - `android.permission.INTERNET`
  - `android.permission.CHANGE_WIFI_MULTICAST_STATE`
@@ -82,7 +82,7 @@ if you want to have Amazon Fling SDK support.
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
-###Metadata for application tag
+### Metadata for application tag
 This metadata tag is necessary to enable Chromecast support.
 
 ```xml
@@ -96,14 +96,14 @@ This metadata tag is necessary to enable Chromecast support.
 </application>
 ```
 
-###Proguard configuration
+### Proguard configuration
 Add the following line to your proguard configuration file (otherwise `DiscoveryManager` won't be able to set any `DiscoveryProvider`).
 
 ```
 -keep class com.connectsdk.**       { * ; }
 ```
 
-###Tests
+### Tests
 Connect SDK has unit tests for some parts of the code, and we are continuing to increase the test coverage.
 These tests are based on third party libraries such as Robolectric, Mockito and PowerMock. You can easily run these tests with Gradle:
 ```
@@ -115,9 +115,9 @@ gradle jacocoTestReport
 ```
 The test coverage report will be in this folder `Connect-SDK-Android/build/reports/jacoco/jacocoTestReport/html`.
 
-##Limitations/Caveats
+## Limitations/Caveats
 
-###Subtitles
+### Subtitles
 
 - DLNA service support `SRT` format only. Since there is no official specification for them, subtitles may not work on all DLNA-compatible devices. This feature has been tested and works on LG WebOS and Netcast TVs.
 - FireTV service supports `WebVTT` format only. Subtitles on Fire TV are hidden by default. To display them, the user should manually pick one in the media player (click the "Options" button on the remote). The Fling SDK doesn't provide any way to make them appear remotely.
@@ -127,14 +127,14 @@ The test coverage report will be in this folder `Connect-SDK-Android/build/repor
 
 
 
-##Contact
+## Contact
 * Twitter [@ConnectSDK](https://www.twitter.com/ConnectSDK)
 * Ask a question on Stack Overflow with the [Connect-SDK tag](https://stackoverflow.com/tags/connect-sdk) (or [TV tag](https://stackoverflow.com/tags/tv))
 * General Inquiries info@connectsdk.com
 * Developer Support support@connectsdk.com
 * Partnerships partners@connectsdk.com
 
-##Credits
+## Credits
 Connect SDK for Android makes use of the following projects, some of which are open-source.
 
 * [Amazon Fling SDK](https://developer.amazon.com/fling)
@@ -152,7 +152,7 @@ These projects are used in tests:
 * [PowerMock](https://github.com/jayway/powermock) (Apache License, Version 2.0)
 * [XMLUnit](http://www.xmlunit.org/) (Apache License, Version 2.0)
 
-##License
+## License
 Copyright (c) 2013-2015 LG Electronics.
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
