### PR TITLE
PLAT-47664: LG TV Plus app crash on disconnecting TV in android 8.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ android.testOptions.unitTests.all {
  }
 
 dependencies {
-    compile files('core/libs/java-websocket-patch.jar')
+    compile files('core/libs/Java-WebSocket-1.3.7.jar')
     compile files('core/libs/javax.jmdns_3.4.1-patch2.jar')
 
     compile fileTree(dir: 'modules/firetv/libs', include: '*.jar')


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
On Android OS Version 8.1.0 disconnecting TV crashes LG TV Plus app

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated the build gradle file to include new version of Web-Socket Lib(1.3.7)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Working in all previous versions too

### Links
[//]: # (Related issues, references)
PLAT-47664

### Comments
Enact-DCO-1.1-Signed-off-by: Anish TD(anish.td@lge.com)