### PR TITLE
Create Erroruse method -> Environment.getExternalStoragePublicDirectory()  java.io.FileNotFoundException: /storage/emulated/0/Download open failed: EACCES (Permission denied)

### DIFF
--- a/Error
+++ b/Error
@@ -1,0 +1,3 @@
+use method -> Environment.getExternalStoragePublicDirectory()
+
+java.io.FileNotFoundException: /storage/emulated/0/Download open failed: EACCES (Permission denied)


### PR DESCRIPTION
use method -> Environment.getExternalStoragePublicDirectory()

java.io.FileNotFoundException: /storage/emulated/0/Download open failed: EACCES (Permission denied)